### PR TITLE
build: compile libraries at installation time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ ENV PATH="/root/.local/bin/:$PATH"
 COPY uv.lock pyproject.toml ./
 
 # Install dependencies using uv (only dependencies, not the project itself)
-RUN UV_PROJECT_ENVIRONMENT=${VENV_PATH} uv sync --frozen --no-install-project
+RUN UV_PROJECT_ENVIRONMENT=${VENV_PATH} uv sync --frozen --no-install-project --compile-bytecode
 RUN ${BIN_PATH}/python -m ensurepip
 # --------------- `final` stage --------------- 
 FROM base AS final


### PR DESCRIPTION
--compile-bytecode compiles installed dependencies after installing it, instead of having them compiled the first time they're imported.

This will translate in less execution time the first time the docker image is run.