### PR TITLE
feat: allow to introduce any model for supported agents

### DIFF
--- a/eval/cli.py
+++ b/eval/cli.py
@@ -26,6 +26,7 @@ from eval.utils import EvalConfig, EvalFileConfig
     ),
 )
 @click.option("--prompt", type=str, help=("Which prompt to use."))
+@click.option("--model", type=str, default=None, help=("Which prompt to use."))
 @click.option(
     "--prompt-file",
     type=str,
@@ -55,6 +56,7 @@ def run(
     prompt_file: str,
     env_file: str,
     tag: str | None = None,
+    model: str | None = None,
 ) -> None:
     load_dotenv(env_file)
     config_from_file = EvalFileConfig.get_config_from_file(config_section=config, path=config_file)
@@ -65,6 +67,7 @@ def run(
             "prompt": prompt or config_from_file.prompt,
             "score_threshold": score or config_from_file.score_threshold,
             "samples": samples or config_from_file.samples,
+            "model": model or config_from_file.model,
         }
     )
 
@@ -76,6 +79,7 @@ def run(
         tag=tag,
         agent=eval_config.agent,
         prompt=configured_prompts.get_prompt(eval_config.prompt),
+        model=eval_config.model,
     )
 
 

--- a/eval/evaluator.py
+++ b/eval/evaluator.py
@@ -1,6 +1,6 @@
 import logging
 
-from lightman_ai.ai.utils import get_agent_instance_from_agent_name
+from lightman_ai.ai.utils import get_agent_class_from_agent_name
 from lightman_ai.article.models import Article
 
 from eval.classifier import Classifier
@@ -11,6 +11,7 @@ logger = logging.getLogger("eval")
 
 
 def eval(
+    *,
     prompt: str,
     score_threshold: int,
     relevant_articles: set[Article],
@@ -18,9 +19,11 @@ def eval(
     samples: int,
     tag: str | None,
     agent: str,
+    model: str | None,
 ) -> None:
+    agent_class = get_agent_class_from_agent_name(agent)
     classified_articles = Classifier(
-        agent=get_agent_instance_from_agent_name(agent)(prompt),
+        agent=agent_class(prompt, model=model),
         score=score_threshold,
         relevant_articles=relevant_articles,
         non_relevant_articles=non_relevant_articles,
@@ -36,6 +39,7 @@ def eval(
         prompt=prompt,
         score=score_threshold,
         logger=logger,
+        model=model or agent_class._default_model_name,
     )
 
     results_template.save()

--- a/eval/templates.py
+++ b/eval/templates.py
@@ -17,6 +17,7 @@ class ResultsFileBuilder:
         samples: int,
         prompt: str,
         score: int,
+        model: str,
         logger: logging.Logger | None = None,
     ) -> None:
         self.results_metrics = results_metrics
@@ -26,6 +27,7 @@ class ResultsFileBuilder:
         self.prompt = prompt
         self.score = score
         self.results_dir = Path(RESULTS_DIR)
+        self.model = model
         self.logger = logger or logging.getLogger("eval")
 
     @property
@@ -55,6 +57,7 @@ class ResultsFileBuilder:
 # Summary
 - Tag: {self.tag or "-"}
 - Agent: {self.agent}
+- Model: {self.model}
 - Samples: {self.samples}
 - Score threshold: {self.score}
 - Prompt: \n {self.prompt}

--- a/justfile
+++ b/justfile
@@ -1,11 +1,13 @@
 # VARIABLE DEFINITIONS
 venv := ".venv"
 python_version :="3.13"
+run := "poetry run"
+eval_path := "eval/cli.py"
 
 venv-exists := path_exists(venv)
 
 
-target_dirs := "src tests"
+target_dirs := "src tests eval"
 
 # ALIASES
 alias t := test
@@ -19,6 +21,9 @@ venv:
     uv sync --frozen --all-extras; \
     fi
 
+# Runs the evaluation script
+eval *args: venv
+    PYTHONPATH=. {{ run }} python {{ eval_path }} {{ args }}
 
 # Cleans all artifacts generated while running this project, including the virtualenv.
 clean: 
@@ -27,17 +32,17 @@ clean:
 
 # Runs the tests with the specified arguments (any path or pytest argument).
 test *test-args='': venv
-    uv run pytest {{ test-args }} --no-cov 
+    {{ run }}  pytest {{ test-args }} --no-cov 
 
 # Runs all tests including coverage report.
 test-all: venv
-    uv run pytest
+    {{ run }}  pytest
 
 # Format all code in the project.
 format:  venv
-    uv run ruff check {{ target_dirs }} --fix
+    {{ run }} ruff check {{ target_dirs }}
 
 # Lint all code in the project.
 lint: venv
-    uv run ruff check {{ target_dirs }}
-    uv run mypy {{ target_dirs }}
+    {{ run }}  ruff check {{ target_dirs }}
+    {{ run }}  mypy {{ target_dirs }}

--- a/lightman.toml
+++ b/lightman.toml
@@ -2,7 +2,6 @@
 agent = 'openai'
 score_threshold = 8
 prompt = 'classify'
-
 service_desk_project_key=''
 service_desk_request_id_type=''
 
@@ -11,6 +10,7 @@ agent = 'openai'
 score_threshold = 8
 prompt = 'classify'
 samples = 3
+model = 'gpt-4o'
 
 [prompts]
 classify = ""

--- a/src/lightman_ai/ai/base/agent.py
+++ b/src/lightman_ai/ai/base/agent.py
@@ -9,13 +9,13 @@ from pydantic_ai.models.openai import OpenAIModel
 
 
 class BaseAgent(ABC):
-    _model: type[OpenAIModel] | type[GoogleModel]
-    _model_name: str
+    _class: type[OpenAIModel] | type[GoogleModel]
+    _default_model_name: str
 
-    def __init__(self, system_prompt: str, logger: logging.Logger | None = None) -> None:
-        model = self._model(self._model_name)
+    def __init__(self, system_prompt: str, model: str | None = None, logger: logging.Logger | None = None) -> None:
+        agent_model = self._class(model or self._default_model_name)
         self.agent: Agent[Never, SelectedArticlesList] = Agent(
-            model=model, output_type=SelectedArticlesList, system_prompt=system_prompt
+            model=agent_model, output_type=SelectedArticlesList, system_prompt=system_prompt
         )
         self.logger = logger or logging.getLogger("lightman")
 

--- a/src/lightman_ai/ai/gemini/agent.py
+++ b/src/lightman_ai/ai/gemini/agent.py
@@ -9,8 +9,8 @@ from pydantic_ai.models.google import GoogleModel
 class GeminiAgent(BaseAgent):
     """Class that provides an interface to operate with the Gemini model."""
 
-    _model = GoogleModel
-    _model_name = "gemini-2.5-pro-preview-05-06"
+    _class = GoogleModel
+    _default_model_name = "gemini-2.5-pro-preview-05-06"
 
     @override
     def _run_prompt(self, prompt: str) -> SelectedArticlesList:

--- a/src/lightman_ai/ai/openai/agent.py
+++ b/src/lightman_ai/ai/openai/agent.py
@@ -11,8 +11,8 @@ from pydantic_ai.models.openai import OpenAIModel
 class OpenAIAgent(BaseAgent):
     """Class that provides an interface to operate with the OpenAI model."""
 
-    _model = OpenAIModel
-    _model_name = "gpt-4.1"
+    _class = OpenAIModel
+    _default_model_name = "gpt-4.1"
 
     def _execute_agent(self, prompt: str) -> AgentRunResult[SelectedArticlesList]:
         with map_openai_exceptions():

--- a/src/lightman_ai/ai/utils.py
+++ b/src/lightman_ai/ai/utils.py
@@ -5,7 +5,7 @@ from lightman_ai.ai.openai.agent import OpenAIAgent
 AGENT_MAPPING = {"openai": OpenAIAgent, "gemini": GeminiAgent}
 
 
-def get_agent_instance_from_agent_name(agent: str) -> type[BaseAgent]:
+def get_agent_class_from_agent_name(agent: str) -> type[BaseAgent]:
     if agent not in AGENT_MAPPING:
         raise ValueError(f"Agent '{agent}' is not recognized. Available agents: {list(AGENT_MAPPING.keys())}")
     return AGENT_MAPPING[agent]

--- a/src/lightman_ai/cli.py
+++ b/src/lightman_ai/cli.py
@@ -25,6 +25,7 @@ def entry_point() -> None:
     help=(f"Location of the config file containing the prompts. Defaults to `{DEFAULT_CONFIG_FILE}`."),
 )
 @click.option("--prompt", type=str, help=("Which prompt to use"))
+@click.option("--model", type=str, default=None, help=("Which model to use. Must be set in conjunction with --agent."))
 @click.option(
     "--score",
     type=int,
@@ -60,6 +61,7 @@ def run(
     agent: str,
     prompt: str,
     prompt_file: str,
+    model: str | None,
     score: int | None,
     config_file: str,
     config: str,
@@ -80,6 +82,7 @@ def run(
                 "agent": agent or config_from_file.agent,
                 "prompt": prompt or config_from_file.prompt,
                 "score_threshold": score or config_from_file.score_threshold,
+                "model": model or config_from_file.model,
             }
         )
 
@@ -94,6 +97,7 @@ def run(
         dry_run=dry_run,
         project_key=config_from_file.service_desk_project_key,
         request_id_type=config_from_file.service_desk_request_id_type,
+        model=final_config.model,
     )
     relevant_articles_metadata = [f"{article.title} ({article.link})" for article in relevant_articles]
     logger.warning("Found these articles: \n- %s", "\n- ".join(relevant_articles_metadata))

--- a/src/lightman_ai/core/config.py
+++ b/src/lightman_ai/core/config.py
@@ -44,6 +44,7 @@ class FileConfig(BaseModel):
     score_threshold: int | None = None
     service_desk_project_key: str | None = None
     service_desk_request_id_type: str | None = None
+    model: str | None = None
 
     model_config = ConfigDict(extra="forbid")
 
@@ -77,6 +78,7 @@ class FinalConfig(BaseModel):
     prompt: str
     agent: str
     score_threshold: PositiveInt
+    model: str | None = None
 
     @classmethod
     def init_from_dict(cls, data: dict[str, Any]) -> Self:

--- a/src/lightman_ai/main.py
+++ b/src/lightman_ai/main.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 
 from lightman_ai.ai.base.agent import BaseAgent
-from lightman_ai.ai.utils import get_agent_instance_from_agent_name
+from lightman_ai.ai.utils import get_agent_class_from_agent_name
 from lightman_ai.article.models import ArticlesList, SelectedArticle, SelectedArticlesList
 from lightman_ai.integrations.service_desk.integration import (
     ServiceDeskIntegration,
@@ -59,11 +59,12 @@ def lightman(
     project_key: str | None = None,
     request_id_type: str | None = None,
     dry_run: bool = False,
+    model: str | None = None,
 ) -> list[SelectedArticle]:
     articles: ArticlesList = _get_articles()
 
-    agent_class = get_agent_instance_from_agent_name(agent)
-    agent_instance = agent_class(prompt)
+    agent_class = get_agent_class_from_agent_name(agent)
+    agent_instance = agent_class(prompt, model, logger=logger)
     logger.info("Selected %s.", agent_instance)
 
     classified_articles = _classify_articles(

--- a/tests/ai/base/test_agent.py
+++ b/tests/ai/base/test_agent.py
@@ -1,14 +1,13 @@
-import logging
 from typing import override
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 from lightman_ai.ai.base.agent import BaseAgent
 from lightman_ai.article.models import ArticlesList, SelectedArticlesList
 
 
 class FakeAgent(BaseAgent):
-    def __init__(self, system_prompt: str, logger: logging.Logger | None = None) -> None:
-        self.agent = Mock()
+    _class = Mock()
+    _default_model_name = "default model name"
 
     @override
     def _run_prompt(self, prompt: str) -> SelectedArticlesList:
@@ -16,8 +15,26 @@ class FakeAgent(BaseAgent):
 
 
 class TestBaseAgent:
-    def test__get_prompt_result(self, test_prompt: str, thn_news: ArticlesList) -> None:
+    @patch("lightman_ai.ai.base.agent.Agent")
+    def test__get_prompt_result(self, m_agent: Mock, test_prompt: str, thn_news: ArticlesList) -> None:
         """Check that we receive an instance of `SelectedArticlesList` when running the method."""
         agent = FakeAgent(test_prompt)
-        result = agent.get_prompt_result(str(thn_news))
-        assert isinstance(result, SelectedArticlesList)
+
+        with patch("tests.ai.base.test_agent.FakeAgent._run_prompt") as m_run_prompt:
+            agent.get_prompt_result(str(thn_news))
+
+        assert m_run_prompt.call_count == 1
+        assert m_run_prompt.call_args[0][0] == str(thn_news)
+        assert m_agent.call_count == 1
+        assert m_agent.call_args[1]["system_prompt"] == test_prompt
+        assert agent._class.call_count == 1
+        assert agent._class.call_args[0][0] == FakeAgent._default_model_name
+
+    @patch("lightman_ai.ai.base.agent.Agent")
+    def test_agent_is_intantiated_with_model_when_set(self, m_agent: Mock, test_prompt: str) -> None:
+        agent = FakeAgent(test_prompt, model="my model")
+        agent.get_prompt_result("")
+
+        assert m_agent.call_count == 1
+        assert agent._class.call_count == 2
+        assert agent._class.call_args[0][0] == "my model"

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -73,6 +73,7 @@ class TestConfig:
         assert config.agent == "openai"
         assert config.score_threshold == 8
         assert config.prompt == "eval-prompt"
+        assert config.model is None
 
     def test_service_desk_fields_accept_str(self) -> None:
         config = FileConfig(
@@ -128,6 +129,20 @@ class TestConfig:
         assert config.service_desk_project_key is None
         assert config.service_desk_request_id_type is None
 
+    def test_model_parameter_can_be_set_in_config_file(self) -> None:
+        """Test that the model parameter can be set through the config file."""
+        content = """
+        [default]
+        agent = 'openai'
+        score_threshold = 8
+        prompt = 'eval-prompt'
+        model = 'gpt-4o-custom'
+        """
+        with patch_config_file(content=content):
+            config = FileConfig.get_config_from_file(config_section=DEFAULT_CONFIG_SECTION, path=DEFAULT_CONFIG_FILE)
+
+        assert config.model == "gpt-4o-custom"
+
 
 class TestFinalConfig:
     def test_init_error(self) -> None:
@@ -147,6 +162,23 @@ class TestFinalConfig:
                 }
             )
         assert "`score_threshold`: Input should be greater than 0" in exc.value.args[0]
+
+    def test_final_config_accepts_model_parameter(self) -> None:
+        """Test that FinalConfig now accepts a model parameter."""
+        config = FinalConfig.init_from_dict(
+            {"prompt": "test prompt", "agent": "openai", "score_threshold": 5, "model": "gpt-4o-custom"}
+        )
+
+        assert config.prompt == "test prompt"
+        assert config.agent == "openai"
+        assert config.score_threshold == 5
+        assert config.model == "gpt-4o-custom"
+
+    def test_final_config_model_parameter_is_optional(self) -> None:
+        """Test that the model parameter is optional and defaults to None."""
+        config = FinalConfig.init_from_dict({"prompt": "test prompt", "agent": "openai", "score_threshold": 5})
+
+        assert config.model is None
 
 
 class TestPromptConfig:

--- a/tests/eval/test_cli.py
+++ b/tests/eval/test_cli.py
@@ -1,7 +1,7 @@
 from unittest.mock import Mock, call, patch
 
 from click.testing import CliRunner
-from lightman_ai.core.config import PromptConfig
+from lightman_ai.core.config import FileConfig, PromptConfig
 from tests.conftest import patch_config_file
 
 from eval import cli
@@ -15,7 +15,7 @@ class TestEvalCli:
     def test_env_file_parameter(self, m_prompt: Mock, m_config: Mock, m_load_dotenv: Mock, m_eval: Mock) -> None:
         runner = CliRunner()
         m_prompt.return_value = PromptConfig({"eval": "eval prompt"})
-
+        m_config.return_value = FileConfig()
         with patch_config_file():
             result = runner.invoke(
                 cli.run,
@@ -43,7 +43,7 @@ class TestEvalCli:
     def test_default_env_file(self, m_prompt: Mock, m_config: Mock, m_load_dotenv: Mock, m_eval: Mock) -> None:
         runner = CliRunner()
         m_prompt.return_value = PromptConfig({"eval": "eval prompt"})
-
+        m_config.return_value = FileConfig()
         with patch_config_file():
             result = runner.invoke(
                 cli.run,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,7 +2,7 @@ from unittest.mock import ANY, Mock, call, patch
 
 from click.testing import CliRunner
 from lightman_ai import cli
-from lightman_ai.core.config import PromptConfig
+from lightman_ai.core.config import FileConfig, PromptConfig
 from tests.conftest import patch_config_file
 
 
@@ -14,6 +14,8 @@ class TestCli:
     def test_arguments(self, m_prompt: Mock, m_config: Mock, m_lightman: Mock, m_load_dotenv: Mock) -> None:
         runner = CliRunner()
         m_prompt.return_value = PromptConfig({"eval": "eval prompt"})
+        m_config.return_value = FileConfig()
+
         with patch_config_file():
             result = runner.invoke(
                 cli.run,
@@ -35,14 +37,14 @@ class TestCli:
 
         assert result.exit_code == 0
         assert m_lightman.call_count == 1
-
         assert m_lightman.call_args == call(
             agent="gemini",
             prompt="eval prompt",
             score_threshold=1,
             dry_run=False,
-            project_key=ANY,
-            request_id_type=ANY,
+            project_key=None,
+            request_id_type=None,
+            model=None,
         )
         assert m_config.call_count == 1
         assert m_config.call_args == call(config_section="my-config", path="config-path")
@@ -56,6 +58,7 @@ class TestCli:
     def test_custom_env_file(self, m_prompt: Mock, m_config: Mock, m_lightman: Mock, m_load_dotenv: Mock) -> None:
         runner = CliRunner()
         m_prompt.return_value = PromptConfig({"eval": "eval prompt"})
+        m_config.return_value = FileConfig()
         with patch_config_file():
             result = runner.invoke(
                 cli.run,
@@ -73,6 +76,45 @@ class TestCli:
 
         assert result.exit_code == 0
         assert m_load_dotenv.call_args == call("custom.env")
+
+    @patch("lightman_ai.cli.load_dotenv")
+    @patch("lightman_ai.cli.lightman")
+    @patch("lightman_ai.cli.FileConfig.get_config_from_file")
+    @patch("lightman_ai.cli.PromptConfig.get_config_from_file")
+    def test_model_is_set_from_the_cli_when_set(
+        self, m_prompt: Mock, m_config: Mock, m_lightman: Mock, m_load_dotenv: Mock
+    ) -> None:
+        runner = CliRunner()
+        m_prompt.return_value = PromptConfig({"eval": "eval prompt"})
+        m_config.return_value = FileConfig(model="not picked up")
+        with patch_config_file():
+            result = runner.invoke(
+                cli.run,
+                [
+                    "--agent",
+                    "gemini",
+                    "--prompt",
+                    "eval",
+                    "--score",
+                    "1",
+                    "--env-file",
+                    "custom.env",
+                    "--model",
+                    "picked up",
+                ],
+            )
+
+        assert result.exit_code == 0
+        assert m_lightman.call_count == 1
+        assert m_lightman.call_args == call(
+            agent="gemini",
+            prompt="eval prompt",
+            score_threshold=1,
+            dry_run=False,
+            project_key=ANY,
+            request_id_type=ANY,
+            model="picked up",
+        )
 
     @patch("lightman_ai.cli.load_dotenv")
     def test_invalid_config(self, m_load_dotenv: Mock) -> None:
@@ -156,5 +198,6 @@ class TestCli:
             dry_run=True,
             project_key=None,
             request_id_type=None,
+            model=None,
         )
         assert m_config.call_count == 2


### PR DESCRIPTION
This PR introduces a functionality that allows to specify a model to be used in the selected agent. This way, you can try any other model without the need of hardcoding it, as long as it's supported by the pydantic Agent or the AI Model.

It also provides defaults for existing agents, so in case no model is specified it will successfully run.