### PR TITLE
ci: manually build and push docker image

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,17 +65,16 @@ jobs:
           images: elementsinteractive/lightman-ai
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
-        with:
-          images: docker.io/elementsinteractive/lightman-ai
-          context: .
-          file: ./Dockerfile
-          push: true
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=ghcr.io/elementsinteractive/lightman-ai:buildcache
-          cache-to: type=registry,ref=ghcr.io/elementsinteractive/lightman-ai:buildcache,mode=max
+        run: |
+          docker buildx build \                                                                                                  
+          --platform linux/amd64,linux/arm64 \
+          --push \
+          --cache-from=type=registry,ref=ghcr.io/elementsinteractive/lightman-ai:buildcache \
+          --cache-to=type=registry,ref=ghcr.io/elementsinteractive/lightman-ai:buildcache,mode=max \
+          -t docker.io/elementsinteractive/lightman-ai:latest \
+          -t docker.io/elementsinteractive/lightman-ai:${{ steps.meta.outputs.version }} \
+          ${{ steps.meta.outputs.labels }}
+          .
 
   release_notes:
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ readme = "README.md"
 lightman-ai = "lightman_ai.cli:entry_point"
 
 [project.optional-dependencies]
+
 test = [
     "pytest<9.0.0,>=8.0.0",
     "pytest-cov<6.0.0,>=5.0.0",


### PR DESCRIPTION
build-push-action has some known issues with multi architechtures. Because of this, we're replacing it with a manual call to the `docker build` command.