### PR TITLE
fix: Allow bump job to push commits

### DIFF
--- a/.github/workflows/bumpversion.yml
+++ b/.github/workflows/bumpversion.yml
@@ -22,8 +22,6 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
           ref: ${{ github.head_ref }}
-          # Make sure the value of GITHUB_TOKEN will not be persisted in repo's config
-          persist-credentials: false
 
       - name: Configure git
         run: |


### PR DESCRIPTION
Trying to fix https://github.com/elementsinteractive/lightman-ai/pull/64.

https://github.com/elementsinteractive/lightman-ai/pull/64#issue-3259266955