### PR TITLE
feat: replace setuptools with hatchling

### DIFF
--- a/justfile
+++ b/justfile
@@ -29,6 +29,11 @@ eval *args: venv
 clean: 
     @rm -f .coverage*
     @rm -rf {{ venv }}
+    @rm -rf dist/
+    @rm -rf .mypy_cache/
+    @rm -rf .ruff_cache/
+    @rm -rf .pytest_cache/
+
 
 # Runs the tests with the specified arguments (any path or pytest argument).
 test *test-args='': venv
@@ -47,3 +52,11 @@ format:  venv
 lint: venv
     {{ run }} ruff check {{ target_dirs }}
     {{ run }} mypy {{ target_dirs }}
+
+# Build the package using hatchling
+build: venv
+    {{ run }} python -m build
+
+# Install package in development mode
+install-dev: venv
+    {{ run }} pip install -e .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,15 +41,29 @@ local = [
     "pre-commit<4.0.0,>=3.2.2",
     "commitizen<5.0.0,>=4.8.3",
     "codespell<3.0.0,>=2.2.4",
+    "build<2.0.0,>=1.0.0",
 ]
 
 
 [build-system]
-requires = ["setuptools>=61.0"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
-[tool.setuptools.dynamic]
-version = {file = "VERSION"}
+[tool.hatch.version]
+path = "VERSION"
+pattern = "v(?P<version>[^\\s]+)"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/lightman_ai"]
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "/src",
+    "/README.md",
+    "/LICENSE",
+    "/VERSION",
+    "/pyproject.toml",
+]
 
 [tool.pytest.ini_options]
 addopts = """

--- a/uv.lock
+++ b/uv.lock
@@ -43,6 +43,20 @@ wheels = [
 ]
 
 [[package]]
+name = "build"
+version = "1.2.2.post1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "os_name == 'nt'" },
+    { name = "packaging" },
+    { name = "pyproject-hooks" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/46/aeab111f8e06793e4f0e421fcad593d547fb8313b50990f31681ee2fb1ad/build-1.2.2.post1.tar.gz", hash = "sha256:b36993e92ca9375a219c99e606a122ff365a760a2d4bba0caa09bd5278b608b7", size = 46701, upload-time = "2024-10-06T17:22:25.251Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/c2/80633736cd183ee4a62107413def345f7e6e3c01563dbca1417363cf957e/build-1.2.2.post1-py3-none-any.whl", hash = "sha256:1d61c0887fa860c01971625baae8bdd338e517b836a2f70dd1f7aa3a6b2fc5b5", size = 22950, upload-time = "2024-10-06T17:22:23.299Z" },
+]
+
+[[package]]
 name = "cachetools"
 version = "5.5.2"
 source = { registry = "https://pypi.org/simple" }
@@ -507,6 +521,7 @@ lint = [
     { name = "ruff" },
 ]
 local = [
+    { name = "build" },
     { name = "codespell" },
     { name = "commitizen" },
     { name = "ipdb" },
@@ -521,6 +536,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
+    { name = "build", marker = "extra == 'local'", specifier = ">=1.0.0,<2.0.0" },
     { name = "click", specifier = ">=8.1.7,<9.0.0" },
     { name = "codespell", marker = "extra == 'local'", specifier = ">=2.2.4,<3.0.0" },
     { name = "commitizen", marker = "extra == 'local'", specifier = ">=4.8.3,<5.0.0" },
@@ -542,7 +558,7 @@ requires-dist = [
     { name = "tiktoken", specifier = ">=0.9.0,<1.0.0" },
     { name = "tomlkit", specifier = ">=0.13.3,<1.0.0" },
 ]
-provides-extras = ["test", "lint", "local"]
+provides-extras = ["lint", "local", "test"]
 
 [[package]]
 name = "logfire"
@@ -1042,6 +1058,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pyproject-hooks"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/82/28175b2414effca1cdac8dc99f76d660e7a4fb0ceefa4b4ab8f5f6742925/pyproject_hooks-1.2.0.tar.gz", hash = "sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8", size = 19228, upload-time = "2024-09-29T09:24:13.293Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl", hash = "sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913", size = 10216, upload-time = "2024-09-29T09:24:11.978Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
hathcling is a newer and faster build backend than setuptools! This will make our builds faster at the same time that we get rid of old packages.