### PR TITLE
ci: test docker build

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -9,7 +9,8 @@ on:
     branches: ["main"]
 
 jobs:
-  package-build-and-test:
+  test-build-package:
+    name: Test package build
     runs-on: ubuntu-latest
     if: "!startsWith(github.event.head_commit.message, 'bump:')"
 
@@ -38,3 +39,65 @@ jobs:
         run: |
           # Test that the CLI is available and --version works
           uv run lightman-ai --version
+
+  should-test-docker-build:
+    permissions:
+      contents: read
+      pull-requests: read
+    name: Check if should test docker build
+    runs-on: ubuntu-latest
+    if: "!startsWith(github.event.head_commit.message, 'bump:')"
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Check if Dockerfile changed
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: dockerfile-changes
+        with:
+          filters: |
+            dockerfile:
+              - 'Dockerfile'
+              - '.dockerignore'
+    outputs:
+      docker: ${{ steps.dockerfile-changes.outputs.dockerfile }}
+
+  test-docker-build:
+    needs: [should-test-docker-build]
+    name: Test Docker build
+    runs-on: ubuntu-latest
+    if: needs.should-test-docker-build.outputs.docker == 'true' && !startsWith(github.event.head_commit.message, 'bump:')
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
+        with:
+          images: elementsinteractive/lightman-ai
+
+      - name: Build Docker image
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
+        with:
+          images: docker.io/elementsinteractive/lightman-ai
+          context: .
+          file: ./Dockerfile
+          push: false
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=ghcr.io/elementsinteractive/lightman-ai:buildcache


### PR DESCRIPTION
Test that the docker build is correct before and after merging, before the real build&push.
This check will run only if the Dockerfile was modified, to make the average build faster, since building the Dockerfile is very time consuming, even when there's a cache hit.