### PR TITLE
fix: remove caching from latest

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -71,7 +71,6 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: |
             type=registry,ref=ghcr.io/elementsinteractive/lightman-ai:buildcache
-            type=registry,ref=ghcr.io/elementsinteractive/lightman-ai:latest
           cache-to: |
             type=registry,ref=ghcr.io/elementsinteractive/lightman-ai:buildcache,mode=max,compression=zstd,force-compression=true,oci-mediatypes=true
       - name: Delete old cache entries


### PR DESCRIPTION
`:latest` does not exist in our ghcr instance, so it makes no sense to have it there.