### PR TITLE
fix: replace time when running with --today

### DIFF
--- a/src/lightman_ai/cli.py
+++ b/src/lightman_ai/cli.py
@@ -94,7 +94,8 @@ def run(
     if start_date and today:
         raise click.UsageError("--today and --start-date cannot be set at the same time.")
     elif today:
-        start_datetime = datetime.now(ZoneInfo(settings.TIME_ZONE))
+        now = datetime.now(ZoneInfo(settings.TIME_ZONE))
+        start_datetime = datetime.combine(now, time(0, 0), tzinfo=ZoneInfo(settings.TIME_ZONE))
     elif isinstance(start_date, date):
         start_datetime = datetime.combine(start_date, time(0, 0), tzinfo=ZoneInfo(settings.TIME_ZONE))
     else:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,7 +14,7 @@ class TestCli:
     @patch("lightman_ai.cli.lightman")
     @patch("lightman_ai.cli.FileConfig.get_config_from_file")
     @patch("lightman_ai.cli.PromptConfig.get_config_from_file")
-    @freeze_time("2025-07-29")
+    @freeze_time("2025-07-29 19:00:00")
     def test_arguments(self, m_prompt: Mock, m_config: Mock, m_lightman: Mock, m_load_dotenv: Mock) -> None:
         runner = CliRunner()
         m_prompt.return_value = PromptConfig({"eval": "eval prompt"})


### PR DESCRIPTION
the time was not being modified at all. This resulted in, whenever we used --today, trying to retrieve everything from "now" onwards.