### PR TITLE
build: run ensurepip before copying dependency files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,12 +37,15 @@ ENV PATH="/root/.local/bin/:$PATH"
 # Create a fake VERSION file, so that we don't break the cache because of a mismatch in that file
 RUN echo "v0.0.0" > VERSION
 
+RUN UV_PROJECT_ENVIRONMENT=${VENV_PATH} uv venv
+RUN ${BIN_PATH}/python -m ensurepip
+
 # Copy dependency files
 COPY uv.lock pyproject.toml ./
 
 # Install dependencies using uv (only dependencies, not the project itself)
-RUN UV_PROJECT_ENVIRONMENT=${VENV_PATH} uv sync --frozen --all-extras --no-install-project --compile-bytecode
-RUN ${BIN_PATH}/python -m ensurepip
+RUN UV_PROJECT_ENVIRONMENT=${VENV_PATH} uv sync --inexact --frozen --all-extras --no-install-project --compile-bytecode
+
 # --------------- `final` stage --------------- 
 FROM base AS final
 


### PR DESCRIPTION
By doing this we speed up the docker build, since we run ensurepip before copying the dependency files.

Without the --inexact flag the pip installation would be removed when running uv sync, as by default it deletes all packages not preset in the uv.lock file.