### PR TITLE
ci: Create major version tag

### DIFF
--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -39,7 +39,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -33,6 +33,11 @@ jobs:
         name: Create bump and changelog
         run: |
           cz bump --yes --changelog
+
+          PINNED_MAJOR=v${$(cz version -p)%%.*}
+          git tag -d $PINNED_MAJOR || true # Delete previous major version tag
+          git tag  $PINNED_MAJOR HEAD
+
           git push origin HEAD:main
           git push origin --tags
 

--- a/.github/workflows/lgtm.yml
+++ b/.github/workflows/lgtm.yml
@@ -36,12 +36,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR code
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           ref: refs/pull/${{ github.event.issue.number }}/merge
 
       - name: Run LGTM Review
-        uses: elementsinteractive/lgtm-ai-action@v1.0.0
+        uses: elementsinteractive/lgtm-ai-action@a486ea03268e82d7fa11825718457cbb5cd90413 # v1.1.0
         with:
           ai-api-key: ${{ secrets.AI_API_TOKEN }}
           git-api-key: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR will create a tag associated to the major version every time a docker image is published.

For example, if the current version is `v1.1.0`, it will also create a `v1` tag. 

The purpose of this is that it can be used in CI/local environments knowing that you will always get the latest version of `v1.x.x`.