### PR TITLE
build: add docker tags

### DIFF
--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -49,7 +49,14 @@ runs:
       uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # v5.8.0
       with:
         images: ${{ inputs['image-name'] }}
-
+        tags: |
+          type=semver,enable=true,pattern={{raw}}
+          type=semver,enable=true,pattern={{major}},prefix=v
+          type=semver,enable=true,pattern=latest
+          type=ref,event=pr,prefix=pr-,enable=true
+          type=ref,event=branch,branch=main,pattern={{raw}}
+          type=ref,event=branch,branch=main,pattern={{major}},prefix=v
+          type=ref,event=branch,branch=main,pattern=latest
     - name: Build Docker image
       uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
       with:


### PR DESCRIPTION
Overwrites default Docker tags, to include the appropriate versions:
- When an image is published, it will tag that image with its current version (vx.y.z), it's major version number (vx) and latest
- When an image is built on main, same logic applies.
- When an image is built on a pr, the pr-PR_NUMBER tag is applied.