### PR TITLE
fix: docker build requires persist-credentials false

### DIFF
--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -39,8 +39,9 @@ runs:
   using: "composite"
   steps:
     - name: Checkout repository
-      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-
+      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      with:
+        persist-credentials: false
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -51,6 +51,8 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
 
       - name: Check if Dockerfile changed
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
@@ -62,6 +64,7 @@ jobs:
               - '.dockerignore'
             workflow:
               - ./.github/actions/docker-build/action.yml
+              - ./.github/workflows/build-test.yml
     outputs:
       docker: ${{ steps.docker-changes.outputs.docker }}
       workflow: ${{ steps.docker-changes.outputs.workflow }}


### PR DESCRIPTION
`action/checkout v6` introduced a change in the functionality that will include an `Authorization` header by default. This would cause issues when we include our `Authorization` header, resulting in broken builds.

With this fix suggested in https://github.com/actions/checkout/issues/2299, the docker build succeeds.